### PR TITLE
fix nits and missing consistency

### DIFF
--- a/docs/01-Protocol-Versions/Version1.md
+++ b/docs/01-Protocol-Versions/Version1.md
@@ -67,7 +67,7 @@ Given a message `m`, key `k`, and optional footer `f`
 2. Verify that the message begins with `v1.local.`, otherwise throw an
    exception. This constant will be referred to as `h`.
 3. Decode the payload (`m` sans `h`, `f`, and the optional trailing period
-   between `m` and `f`) from b64 to raw binary. Set:
+   between `m` and `f`) from base64url to raw binary. Set:
    * `n` to the leftmost 32 bytes
    * `t` to the rightmost 48 bytes
    * `c` to the middle remainder of the payload, excluding `n` and `t`
@@ -148,7 +148,7 @@ footer `f` (which defaults to empty string):
 2. Verify that the message begins with `v1.public.`, otherwise throw an
    exception. This constant will be referred to as `h`.
 3. Decode the payload (`sm` sans `h`, `f`, and the optional trailing period
-   between `m` and `f`) from b64 to raw binary. Set:
+   between `m` and `f`) from base64url to raw binary. Set:
    * `s` to the rightmost 256 bytes
    * `m` to the leftmost remainder of the payload, excluding `s`
 4. Pack `h`, `m`, and `f` together (in that order) using PAE (see

--- a/docs/01-Protocol-Versions/Version2.md
+++ b/docs/01-Protocol-Versions/Version2.md
@@ -24,9 +24,10 @@ Given a message `m`, key `k`, and optional footer `f`.
    );
    ```
 6. If `f` is:
-   * Empty: return h || b64(n || c)
-   * Non-empty: return h || b64(n || c) || `.` || base64url(f)
+   * Empty: return h || base64url(n || c)
+   * Non-empty: return h || base64url(n || c) || `.` || base64url(f)
    * ...where || means "concatenate"
+   * Note: `base64url()` means Base64url from RFC 4648 without `=` padding.
 
 ## Decrypt
 

--- a/docs/01-Protocol-Versions/Version4.md
+++ b/docs/01-Protocol-Versions/Version4.md
@@ -51,6 +51,7 @@ implicit assertion `i` (which defaults to empty string).
     * Empty: return h || base64url(n || c)
     * Non-empty: return h || base64url(n || c) || `.` || base64url(f)
     * ...where || means "concatenate"
+    * Note: `base64url()` means Base64url from RFC 4648 without `=` padding.
 
 ## Decrypt
 


### PR DESCRIPTION
- adds the Note: where missing
- replaces b64 with base64url to stay consistent across all four versions