### PR TITLE
clarify that mac is returned from encrypt

### DIFF
--- a/docs/01-Protocol-Versions/Version4.md
+++ b/docs/01-Protocol-Versions/Version4.md
@@ -48,8 +48,8 @@ implicit assertion `i` (which defaults to empty string).
    );
    ```
 7. If `f` is:
-    * Empty: return h || base64url(n || c)
-    * Non-empty: return h || base64url(n || c) || `.` || base64url(f)
+    * Empty: return h || base64url(n || c || t)
+    * Non-empty: return h || base64url(n || c || t) || `.` || base64url(f)
     * ...where || means "concatenate"
     * Note: `base64url()` means Base64url from RFC 4648 without `=` padding.
 


### PR DESCRIPTION
In Version 4 `encrypt`, step 6 computes mac. This value is then required in Version 4 `decrypt` step 7.
It would be good to clarify that mac is returned as output from `encrypt`, because otherwise it is not accessible in `decrypt`.