### PR TITLE
Fix typo in java implementation example

### DIFF
--- a/docs/02-Implementation-Guide/03-Algorithm-Lucidity.md
+++ b/docs/02-Implementation-Guide/03-Algorithm-Lucidity.md
@@ -34,7 +34,7 @@ For example, you might implement something like this:
 public enum Version { V1, V2, V3, V4 };
 public enum Purpose { PURPOSE_LOCAL, PURPOSE_PUBLIC }; 
 
-absract class Key {
+abstract class Key {
      protected byte[] material;
      protected Version version;
      


### PR DESCRIPTION
Fixes a minor typo in the java implementation example.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

Thanks for y'all's work on this standard :)