### PR TITLE
Fix decryption step 3 on version 4.

### DIFF
--- a/docs/01-Protocol-Versions/Version4.md
+++ b/docs/01-Protocol-Versions/Version4.md
@@ -79,7 +79,8 @@ implicit assertion `i` (which defaults to empty string).
 3. Decode the payload (`m` sans `h`, `f`, and the optional trailing period
    between `m` and `f`) from base64url to raw binary. Set:
     * `n` to the leftmost 32 bytes
-    * `c` to the middle remainder of the payload, excluding `n`.
+    * `t` to the rightmost 32 bytes
+    * `c` to the middle remainder of the payload, excluding `n` and `t`.
 4. Split the key into an Encryption key (`Ek`) and Authentication key (`Ak`),
    using keyed BLAKE2b, using the domain separation constants and `n` as the
    message, and the input key as the key. The first value will be 56 bytes,


### PR DESCRIPTION
Hi @paragonie-security,

I found a problem in decryption step 3 of version 4. It seems that the process to extract the BLAKE2b-MAC value `t` is missing.

I'd appreciate it if you can check and merge it.

By the way, I've implemented a PASETO library for Python without using libsodium.

PySETO: https://github.com/dajiaji/pyseto

This PySETO supports all of the PASETO versions and purposes (At least, it can process all of [official test vectors](https://github.com/paseto-standard/test-vectors)). I'm very glad if you can add this to the implementation list on https://paseto.io.