### PR TITLE
Deprecate old versions

### DIFF
--- a/docs/01-Protocol-Versions/Version1.md
+++ b/docs/01-Protocol-Versions/Version1.md
@@ -1,5 +1,7 @@
 # Paseto Version 1
 
+> PASETO Version 1 is deprecated. Implementations **SHOULD** migrate to [Version 3](Version3.md).
+
 ## GetNonce
 
 Given a message (`m`) and a nonce (`n`):

--- a/docs/01-Protocol-Versions/Version2.md
+++ b/docs/01-Protocol-Versions/Version2.md
@@ -1,5 +1,7 @@
 # Paseto Version 2
 
+> PASETO Version 2 is deprecated. Implementations **SHOULD** migrate to [Version 4](Version4.md).
+
 ## Encrypt
 
 Before encrypting, first assert that the key being used is intended for use


### PR DESCRIPTION
See https://github.com/paragonie/paseto-io/issues/32

We're currently targeting 2022-01-01 for the deprecation date.