### PR TITLE
Recommend implementing PASERK types for lib interop

### DIFF
--- a/docs/02-Implementation-Guide/03-Algorithm-Lucidity.md
+++ b/docs/02-Implementation-Guide/03-Algorithm-Lucidity.md
@@ -17,6 +17,10 @@ be accepted as a key in any PASETO library, **UNLESS** it's an application-speci
 encoding that encapsulates both the key and an algorithm identifier. (For example,
 a [`k2.local` PASERK](https://github.com/paseto-standard/paserk/blob/master/types/local.md).)
 
+In order to allow for key interoperability between different PASETO libraries,
+any PASETO library **SHOULD** support the `local`, `public` and `secret` types
+from [PASERK](https://github.com/paseto-standard/paserk).
+
 ## Implementation Guidance
 
 ### Object-Oriented Languages


### PR DESCRIPTION
Implementations following this suggestion will get a :heavy_check_mark: in the PASERK column introduced in https://github.com/paragonie/paseto-io/pull/37.