### PR TITLE
[doc] Replace relative ref with absolute ones

### DIFF
--- a/docs/01-Protocol-Versions/Version1.md
+++ b/docs/01-Protocol-Versions/Version1.md
@@ -17,9 +17,8 @@ Given a message `m`, key `k`, and optional footer `f`
    See [Algorithm Lucidity](../02-Implementation-Guide/03-Algorithm-Lucidity.md)
    for more information.
 2. Set header `h` to `v1.local.`
-3. Generate 32 random bytes from the OS's CSPRNG.
-4. Calculate `GetNonce()` of `m` and the output of step 2
-   to get the nonce, `n`.
+3. Generate 32 random bytes from the OS's CSPRNG, `b`.
+4. Calculate `GetNonce()` of `m` and the `b` to get the nonce, `n`.
    * This step is to ensure that an RNG failure does not result
      in a nonce-misuse condition that breaks the security of
      our stream cipher.

--- a/docs/01-Protocol-Versions/Version2.md
+++ b/docs/01-Protocol-Versions/Version2.md
@@ -9,8 +9,8 @@ Given a message `m`, key `k`, and optional footer `f`.
    See [Algorithm Lucidity](../02-Implementation-Guide/03-Algorithm-Lucidity.md)
    for more information.
 2. Set header `h` to `v2.local.`
-3. Generate 24 random bytes from the OS's CSPRNG.
-4. Calculate BLAKE2b of the message `m` with the output of step 2 as the key,
+3. Generate 24 random bytes from the OS's CSPRNG, `b`.
+4. Calculate BLAKE2b of the message `m` with `b` as the key,
    with an output length of 24. This will be our nonce, `n`.
    * This step is to ensure that an RNG failure does not result in a
      nonce-misuse condition that breaks the security of our stream cipher.


### PR DESCRIPTION
Hi, https://github.com/paseto-standard/paseto-spec/pull/14 rearranged steps order, resulting in relative references messed around as such non careful readers could use `v1.local` or `v2.local` as keys instead of the random bytes string.

`b` letter has been chosen not to conflict with other letters present, and to be easily recognizable.