### PR TITLE
Clarify uniqueness requirements in JSON object key names

### DIFF
--- a/docs/02-Implementation-Guide/01-Payload-Processing.md
+++ b/docs/02-Implementation-Guide/01-Payload-Processing.md
@@ -4,6 +4,8 @@ All PASETO payloads must be a JSON-encoded object represented as a UTF-8 encoded
 string. The topmost JSON object should be an object, map, or associative array
 (select appropriate for your language), not a flat array or list.
 
+PASETO library implementors **MUST** ensure uniqueness of object key names.
+
 > **Valid**:
 > 
 > * `{"foo":"bar"}`
@@ -17,6 +19,7 @@ string. The topmost JSON object should be an object, map, or associative array
 > * `{0: "test"}`
 > * `[]`
 > * (Empty string)
+> * `{"foo":"bar","foo":"baz"}`
 
 If non-UTF-8 character sets are desired for some fields, implementors are
 encouraged to use [Base64url](https://tools.ietf.org/html/rfc4648#page-7)


### PR DESCRIPTION
Neither [ECMA-404](https://ecma-international.org/wp-content/uploads/ECMA-404_2nd_edition_december_2017.pdf) nor [RFC8259](https://www.rfc-editor.org/rfc/rfc8259) require that keys in objects be unique, nor do they specify parser behavior in case there are duplicate keys.

A common behavior in production JSON parsers tends to be that an object `{"a": 0, "a": 1}` is accepted and equivalent to `{"a": 1}`, however others may reject it or return an object equivalent to `{"a": 0}`.